### PR TITLE
Adjust the time for stale branch check

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,7 +1,7 @@
 name: Stale Branches
 on:
   schedule:
-    - cron: '0 0/4 * * *'
+    - cron: '0 1/4 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
Make the run time cover 5pm EDT so it can be in sync with the scheduled reminder bot.